### PR TITLE
fix(#14): handle uncompressed rotated log files

### DIFF
--- a/agent/pkg/logs/logs.go
+++ b/agent/pkg/logs/logs.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -21,6 +22,22 @@ type Position struct {
 type LogResult struct {
 	Logs      []string   `json:"logs"`
 	Positions []Position `json:"positions,omitempty"`
+}
+
+func isNumericExtension(ext string) bool {
+	if len(ext) < 2 || ext[0] != '.' {
+		return false
+	}
+	_, err := strconv.Atoi(ext[1:])
+	return err == nil
+}
+
+func isRotatedLogFile(name string) bool {
+	ext := filepath.Ext(name)
+	if !isNumericExtension(ext) {
+		return false
+	}
+	return strings.HasSuffix(strings.TrimSuffix(name, ext), ".log")
 }
 
 func GetLogs(path string, positions []Position, isErrorLog bool, includeCompressed bool) (LogResult, error) {
@@ -157,13 +174,17 @@ func GetDirectoryLogs(dirPath string, positions []Position, isErrorLog bool, inc
 	// Filter log files
 	var logFiles []string
 	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
 		fileName := entry.Name()
 		// Check if it's a log file
 		isLogFile := strings.HasSuffix(fileName, ".log")
 		isGzipFile := strings.HasSuffix(fileName, ".gz")
+		isRotated := isRotatedLogFile(fileName)
 
 		// Filter by log type and extension
-		if (isLogFile || (isGzipFile && includeCompressed)) &&
+		if (isLogFile || isRotated || (isGzipFile && includeCompressed)) &&
 			(isErrorLog && strings.Contains(fileName, "error") || !isErrorLog && !strings.Contains(fileName, "error")) {
 			logFiles = append(logFiles, fileName)
 		}
@@ -214,7 +235,7 @@ func GetDirectoryLogs(dirPath string, positions []Position, isErrorLog bool, inc
 			}
 
 			r := fileResult{logs: result.Logs}
-			if strings.HasSuffix(fp.Filename, ".log") {
+			if !strings.HasSuffix(fp.Filename, ".gz") {
 				var pos int64
 				if len(result.Positions) > 0 {
 					pos = result.Positions[0].Position

--- a/agent/pkg/logs/logs_test.go
+++ b/agent/pkg/logs/logs_test.go
@@ -1,1 +1,135 @@
 package logs
+
+import (
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestGetDirectoryLogs_RotatedFiles(t *testing.T) {
+	// Setup test directory
+	dirPath, err := os.MkdirTemp("", "test_logs")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dirPath)
+
+	// Create test log files
+	files := map[string]string{
+		"access.log":      "today logs\n",
+		"access.log.1":    "yesterday logs\n",
+		"access.log.2.gz": "older logs\n",
+		"error.log":       "error logs\n",
+		"notes.1":         "not a log\n",
+	}
+
+	for name, content := range files {
+		fullPath := filepath.Join(dirPath, name)
+		if filepath.Ext(name) == ".gz" {
+			f, err := os.Create(fullPath)
+			if err != nil {
+				t.Fatalf("Failed to create gzip file %s: %v", name, err)
+			}
+			gw := gzip.NewWriter(f)
+			if _, err := gw.Write([]byte(content)); err != nil {
+				t.Fatalf("Failed to write gzip file %s: %v", name, err)
+			}
+			if err := gw.Close(); err != nil {
+				t.Fatalf("Failed to close gzip writer for %s: %v", name, err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatalf("Failed to close gzip file %s: %v", name, err)
+			}
+		} else {
+			err := os.WriteFile(fullPath, []byte(content), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file %s: %v", name, err)
+			}
+		}
+	}
+
+	tests := []struct {
+		name              string
+		isErrorLog        bool
+		includeCompressed bool
+		wantLogs          []string
+		wantPositions     []string
+		}{
+		{
+			name:              "Access logs - no compressed",
+			isErrorLog:        false,
+			includeCompressed: false,
+			wantLogs:          []string{"today logs", "yesterday logs"},
+			wantPositions:     []string{"access.log", "access.log.1"},
+		},
+		{
+			name:              "Access logs - with compressed",
+			isErrorLog:        false,
+			includeCompressed: true,
+			wantLogs:          []string{"today logs", "yesterday logs", "older logs"},
+			wantPositions:     []string{"access.log", "access.log.1"},
+		},
+		{
+			name:              "Error logs",
+			isErrorLog:        true,
+			includeCompressed: false,
+			wantLogs:          []string{"error logs"},
+			wantPositions:     []string{"error.log"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetDirectoryLogs(dirPath, nil, tt.isErrorLog, tt.includeCompressed)
+			if err != nil {
+				t.Fatalf("GetDirectoryLogs failed: %v", err)
+			}
+
+			if !slices.Equal(result.Logs, tt.wantLogs) {
+				t.Fatalf("unexpected logs: got %v want %v", result.Logs, tt.wantLogs)
+			}
+
+			var gotPositions []string
+			for _, pos := range result.Positions {
+				gotPositions = append(gotPositions, pos.Filename)
+			}
+			if !slices.Equal(gotPositions, tt.wantPositions) {
+				t.Fatalf("unexpected positions: got %v want %v", gotPositions, tt.wantPositions)
+			}
+
+			for _, unexpected := range []string{"not a log", "error logs", "older logs"} {
+				if tt.isErrorLog || tt.includeCompressed {
+					if unexpected == "error logs" || unexpected == "older logs" {
+						continue
+					}
+				}
+				if slices.Contains(result.Logs, unexpected) {
+					t.Errorf("unexpected log line %q was returned", unexpected)
+				}
+			}
+		})
+	}
+}
+
+func TestIsNumericExtension(t *testing.T) {
+	tests := []struct {
+		ext      string
+		expected bool
+	}{
+		{".1", true},
+		{".10", true},
+		{".log", false},
+		{".gz", false},
+		{".", false},
+		{"", false},
+		{".1a", false},
+	}
+
+	for _, tt := range tests {
+		if result := isNumericExtension(tt.ext); result != tt.expected {
+			t.Errorf("isNumericExtension(%s) = %v; want %v", tt.ext, result, tt.expected)
+		}
+	}
+}

--- a/agent/pkg/logs/size.go
+++ b/agent/pkg/logs/size.go
@@ -55,10 +55,10 @@ func GetLogSizes(dirPath string) (LogSizes, error) {
 			summary.TotalSize += fileSize
 			summary.TotalFiles++
 
-			if extension == ".log" {
-				summary.LogFilesSize += fileSize
-				summary.LogFilesCount++
-			} else if extension == ".gz" || extension == ".zip" || extension == ".tar" {
+				if extension == ".log" || isRotatedLogFile(fileName) {
+					summary.LogFilesSize += fileSize
+					summary.LogFilesCount++
+				} else if extension == ".gz" || extension == ".zip" || extension == ".tar" {
 				summary.CompressedFilesSize += fileSize
 				summary.CompressedFilesCount++
 			}
@@ -100,20 +100,16 @@ func GetLogSize(filePath string) (LogSizes, error) {
 			},
 		},
 		Summary: LogFilesSummary{
-			TotalSize:            fileSize,
-			LogFilesSize:         fileSize,
-			CompressedFilesSize:  0,
-			TotalFiles:           1,
-			LogFilesCount:        1,
-			CompressedFilesCount: 0,
+			TotalSize:  fileSize,
+			TotalFiles: 1,
 		},
 	}
 
-	// If it's a compressed file, update the summary
-	if extension == ".gz" || extension == ".zip" || extension == ".tar" {
-		response.Summary.LogFilesSize = 0
+	if extension == ".log" || isRotatedLogFile(fileName) {
+		response.Summary.LogFilesSize = fileSize
+		response.Summary.LogFilesCount = 1
+	} else if extension == ".gz" || extension == ".zip" || extension == ".tar" {
 		response.Summary.CompressedFilesSize = fileSize
-		response.Summary.LogFilesCount = 0
 		response.Summary.CompressedFilesCount = 1
 	}
 

--- a/agent/pkg/logs/size_test.go
+++ b/agent/pkg/logs/size_test.go
@@ -1,123 +1,74 @@
 package logs
 
-// import (
-// 	"encoding/json"
-// 	"net/http"
-// 	"net/http/httptest"
-// 	"os"
-// 	"testing"
-// )
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-// func TestServeLogsSize(t *testing.T) {
-// 	// Setup test directory
-// 	dirPath := "test_logs"
-// 	err := os.Mkdir(dirPath, 0755)
-// 	if err != nil {
-// 		t.Fatalf("Failed to create test directory: %v", err)
-// 	}
-// 	defer os.RemoveAll(dirPath)
+func TestGetLogSizes_RotatedFiles(t *testing.T) {
+	// Setup test directory
+	dirPath, err := os.MkdirTemp("", "test_logs_size")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dirPath)
 
-// 	// Create test files
-// 	logFile := filepath.Join(dirPath, "test.log")
-// 	err = os.WriteFile(logFile, []byte("log content"), 0644)
-// 	if err != nil {
-// 		t.Fatalf("Failed to create test log file: %v", err)
-// 	}
+	// Create test files
+	files := map[string]int64{
+		"access.log":   100,
+		"access.log.1": 200,
+		"test.gz":      50,
+		"notes.1":      25,
+	}
 
-// 	zipFile := filepath.Join(dirPath, "test.zip")
-// 	err = os.WriteFile(zipFile, []byte("compressed content"), 0644)
-// 	if err != nil {
-// 		t.Fatalf("Failed to create test zip file: %v", err)
-// 	}
+	for name, size := range files {
+		err := os.WriteFile(filepath.Join(dirPath, name), make([]byte, size), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", name, err)
+		}
+	}
 
-// 	// Create request and response recorder
-// 	r, _ := http.NewRequest("GET", "/logs-size", nil)
-// 	w := httptest.NewRecorder()
+	result, err := GetLogSizes(dirPath)
+	if err != nil {
+		t.Fatalf("GetLogSizes failed: %v", err)
+	}
 
-// 	// Call the function
-// 	ServeLogsSize(w, r, dirPath)
+	// access.log and access.log.1 should be counted as log files, but unrelated .1 files should not.
+	if result.Summary.LogFilesCount != 2 {
+		t.Errorf("Expected 2 log files, got %d", result.Summary.LogFilesCount)
+	}
+	if result.Summary.LogFilesSize != 300 {
+		t.Errorf("Expected 300 log files size, got %d", result.Summary.LogFilesSize)
+	}
+	if result.Summary.TotalFiles != 4 {
+		t.Errorf("Expected 4 total files, got %d", result.Summary.TotalFiles)
+	}
+	if result.Summary.CompressedFilesCount != 1 {
+		t.Errorf("Expected 1 compressed file, got %d", result.Summary.CompressedFilesCount)
+	}
+}
 
-// 	// Check response status
-// 	if w.Code != http.StatusOK {
-// 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
-// 	}
+func TestGetLogSize_RotatedFile(t *testing.T) {
+	// Create test log file
+	logFile, err := os.CreateTemp("", "access.log.1")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(logFile.Name())
+	
+	logFile.Write(make([]byte, 150))
+	logFile.Close()
 
-// 	// Parse response
-// 	var result LogSizes
-// 	err = json.Unmarshal(w.Body.Bytes(), &result)
-// 	if err != nil {
-// 		t.Fatalf("Failed to parse JSON response: %v", err)
-// 	}
+	result, err := GetLogSize(logFile.Name())
+	if err != nil {
+		t.Fatalf("GetLogSize failed: %v", err)
+	}
 
-// 	// Validate file count
-// 	if len(result.Files) != 2 {
-// 		t.Errorf("Expected 2 files, got %d", len(result.Files))
-// 	}
-
-// 	// Validate summary
-// 	if result.Summary.TotalFiles != 2 {
-// 		t.Errorf("Expected total files to be 2, got %d", result.Summary.TotalFiles)
-// 	}
-// 	if result.Summary.LogFilesCount != 1 {
-// 		t.Errorf("Expected 1 log file, got %d", result.Summary.LogFilesCount)
-// 	}
-// 	if result.Summary.CompressedFilesCount != 1 {
-// 		t.Errorf("Expected 1 compressed file, got %d", result.Summary.CompressedFilesCount)
-// 	}
-// }
-
-// func TestServeLogSize(t *testing.T) {
-// 	// Create test log file
-// 	logFile := "test.log"
-// 	err := os.WriteFile(logFile, []byte("test log data"), 0644)
-// 	if err != nil {
-// 		t.Fatalf("Failed to create test log file: %v", err)
-// 	}
-// 	defer os.Remove(logFile)
-
-// 	// Create request and response recorder
-// 	r, _ := http.NewRequest("GET", "/log-size", nil)
-// 	w := httptest.NewRecorder()
-
-// 	// Call the function
-// 	ServeLogSize(w, r, logFile)
-
-// 	// Check response status
-// 	if w.Code != http.StatusOK {
-// 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
-// 	}
-
-// 	// Parse response
-// 	var result LogSizes
-// 	err = json.Unmarshal(w.Body.Bytes(), &result)
-// 	if err != nil {
-// 		t.Fatalf("Failed to parse JSON response: %v", err)
-// 	}
-
-// 	// Validate single file
-// 	if len(result.Files) != 1 {
-// 		t.Errorf("Expected 1 file, got %d", len(result.Files))
-// 	}
-
-// 	// Validate summary
-// 	if result.Summary.TotalFiles != 1 {
-// 		t.Errorf("Expected total files to be 1, got %d", result.Summary.TotalFiles)
-// 	}
-// 	if result.Summary.LogFilesCount != 1 {
-// 		t.Errorf("Expected log files count to be 1, got %d", result.Summary.LogFilesCount)
-// 	}
-// }
-
-// func TestServeNonExistentLogSize(t *testing.T) {
-// 	// Create request for a non-existent file
-// 	r, _ := http.NewRequest("GET", "/log-size", nil)
-// 	w := httptest.NewRecorder()
-
-// 	// Call the function
-// 	ServeLogSize(w, r, "non_existent.log")
-
-// 	// Check response status
-// 	if w.Code != http.StatusNotFound {
-// 		t.Errorf("Expected status %d, got %d", http.StatusNotFound, w.Code)
-// 	}
-// }
+	if result.Summary.LogFilesCount != 1 {
+		t.Errorf("Expected 1 log file, got %d", result.Summary.LogFilesCount)
+	}
+	if result.Summary.LogFilesSize != 150 {
+		t.Errorf("Expected 150 log files size, got %d", result.Summary.LogFilesSize)
+	}
+}


### PR DESCRIPTION
Closes #14.

## Summary

Handle default `logrotate` setups that use `delaycompress` by including uncompressed rotated files such as `access.log.1` in analytics and log size summaries.

## Changes

- include `*.log.<number>` files when reading logs from a directory
- preserve positions for uncompressed rotated log files
- count rotated log files in size summaries
- exclude unrelated numeric-suffix files such as `notes.1`
- add stronger test coverage for rotated log handling

## Testing

- `go test ./pkg/logs`
- `go test ./...`